### PR TITLE
added support for launching a process as a specific user and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Role Variables
   * `target`: Target of monitorization. Should be a pidfile, an address or undefined, depending on the `type` of service.
   * `start`: Command that starts the service. Optional.
   * `stop`: Command that stop the service. Optional.
+  * `user`: Linux username of the user starting the program. Optional.
+  * `group`: Linux group of the user starting the program. Optional.
   * `rules`: List of rules to be included in this service. Optional.
 * `monit_service_detele_unlisted`: Remove existing service monitorization configurations not declared in the `services`. Defaults to `true`.
 * `monit_mail_enabled`: Enable mail alerts. Defaults to `false`.

--- a/templates/monitor.j2
+++ b/templates/monitor.j2
@@ -4,10 +4,10 @@
 {% if monit_monitor.type == 'process' %}
 check process {{ monit_monitor.name }} with pidfile {{ monit_monitor.target }}
 {% if monit_monitor.start is defined %}
-  start program = "{{ monit_monitor.start }}"
+  start program = "{{ monit_monitor.start }}" {% if monit_monitor.user is defined %} as uid {{monit_monitor.user}} {% endif %} {% if monit_monitor.group is defined %} and gid {{monit_monitor.group}} {% endif %}
 {% endif %}
 {% if monit_monitor.stop is defined %}
-  stop program = "{{ monit_monitor.stop }}"
+  stop program = "{{ monit_monitor.stop }}" {% if monit_monitor.user is defined %} as uid {{monit_monitor.user}} {% endif %} {% if monit_monitor.group is defined %} and gid {{monit_monitor.group}} {% endif %}
 {% endif %}
 {% elif monit_monitor.type == 'system' %}
 check system {{ monit_monitor.name }}
@@ -16,6 +16,7 @@ check host {{ monit_monitor.name }} with address {{ monit_monitor.target }}
 {% elif monit_monitor.type == 'filesystem' %}
 check filesystem {{ monit_monitor.name }} with path {{ monit_monitor.target }}
 {% endif -%}
+
 {% if monit_monitor.rules is defined %}
 {% for rule in monit_monitor.rules %}
   {{ rule }}


### PR DESCRIPTION
Hi, 

I am using your monit role as part of my cluster deployment solution, thanks a lot for making this one public!

I need to be able to start programs as a specific user, which monit allows through the "as uid" and "and gid" options. 

=> I added 2 optional variables: 
* monit_monitor.user 
*monit_monitor.group

If they are defined, the corresponding options are added to the monit config. If not, the role behaves exactly as before. 

Hope you like this :) 

S


