### PR TITLE
Fix typos in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Role Variables
 * `monit_service_detele_unlisted`: Remove existing service monitorization configurations not declared in the `services`. Defaults to `true`.
 * `monit_mail_enabled`: Enable mail alerts. Defaults to `false`.
 * `monit_mailserver_host`: Mailserver host address. Defaults to `localhost`.
-* `monit_mailserver_host`: Mailserver host port. Defaults to `25`.
+* `monit_mailserver_port`: Mailserver host port. Defaults to `25`.
 * `monit_mailserver_user`: Username for authentication on mailserver.
 * `monit_mailserver_password`: Password for authentication on mailserver.
 * `monit_mailserver_timeout`: Timeout for mailserver connection. Defaults to `5`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ansible role for configuring Monit. Sample usage see [example.yml](http://github
 Requirements
 ------------
 
-An ansible ready host.
+An Ansible ready host.
 
 Role Variables
 --------------


### PR DESCRIPTION
The `monit_mailserver_host` role variable was duplicated: The last one should obviously be `monit_mailserver_port`. Also, capitalize Ansible in the Requirements section.

:smiley: 