### PR TITLE
Flexible mail-format allowing single option overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ Role Variables
 * `monit_mailserver_timeout`: Timeout for mailserver connection. Defaults to `5`.
 * `monit_mailserver_ssl_version`: If defined, monit will use this algorithm for SSL connection to the mail server. Possible values are `SSLAUTO`, `SSLV2`, `SSLV3`, `TLSV1`, `TLSV11`, `TLSV12`.
 * `monit_alert_address`: Mail address where the alerts will be sent to.
-* `monit_alert_mail_from`: Sender mail address.
-* `monit_alert_mail_subject`: Mail subject.
-* `monit_alert_mail_message`: Mail message body.
+* `monit_alert_mail_format`: A hash of options for mail-format.
+  * `from`: Sender mail address.
+  * `reply-to`: A reply-to mail address.
+  * `subject`: Mail subject.
+  * `message`: Mail message body.
 * `monit_webinterface_enabled`: Enable monit web interface. Defaults to `true`.
 * `monit_webinterface_bind`: IP address to bind web interface. Defaults to `0.0.0.0` (listen for external requests).
 * `monit_webinterface_port`: Port for web interface. Defaults to `2812`.

--- a/templates/mail.j2
+++ b/templates/mail.j2
@@ -10,9 +10,12 @@ set mailserver {{ monit_mailserver_host }} port {{ monit_mailserver_port }}
 
 set alert {{ monit_alert_address }}
 
+{% if monit_alert_mail_format is defined -%}
 set mail-format {
-  from: {{ monit_alert_mail_from }}
-  subject: {{ monit_alert_mail_subject }}
-  message: {{ monit_alert_mail_message }}
+{% for key in ['from', 'reply-to', 'subject', 'message'] -%}
+{% if monit_alert_mail_format[key] is defined %}
+  {{ key }}: {{ monit_alert_mail_format[key] }}
+{% endif %}
+{% endfor -%}
 }
-
+{% endif -%}


### PR DESCRIPTION
Hey,

Here's a small PR allowing for flexible mail-format overrides. Most of the times there's no need to override all values at once. It also supports a `reply-to` option.

I've updated the README file accordingly.

Unfortunately this change is backwards incompatible.