### PR TITLE
Don't require sendmail user and/or password

### DIFF
--- a/templates/mail.j2
+++ b/templates/mail.j2
@@ -1,7 +1,9 @@
 # {{ ansible_managed }}
 
 set mailserver {{ monit_mailserver_host }} port {{ monit_mailserver_port }}
+  {% if monit_mailserver_user is defined and monit_mailserver_password is defined -%}
   username "{{ monit_mailserver_user }}" password "{{ monit_mailserver_password }}"
+  {% endif -%}
   {% if monit_mailserver_ssl_version is defined -%}
   using {{ monit_mailserver_ssl_version }}
   {% endif -%}


### PR DESCRIPTION
These are obsolete for our usecase, but still the template requires them (and leaving them empty makes the role error). This PR checks if they are filled in, and if not skips the username and password criteria in the mail template.